### PR TITLE
Add optional array key in filter search

### DIFF
--- a/src/AtLeast.php
+++ b/src/AtLeast.php
@@ -40,8 +40,12 @@ final class AtLeast
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
      * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    private static function hasFoundTimes(iterable $data, callable $filter, int $maxCount, bool $includeKey = false): bool
-    {
+    private static function hasFoundTimes(
+        iterable $data,
+        callable $filter,
+        int $maxCount,
+        bool $includeKey = false
+    ): bool {
         // usage must be higher than 0
         Assert::greaterThan($maxCount, 0);
 

--- a/src/AtLeast.php
+++ b/src/AtLeast.php
@@ -11,43 +11,43 @@ final class AtLeast
 {
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed>  $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function once(iterable $data, callable $filter): bool
+    public static function once(iterable $data, callable $filter, bool $includeKey = false): bool
     {
-        return self::hasFoundTimes($data, $filter, 1);
+        return self::hasFoundTimes($data, $filter, 1, $includeKey);
     }
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function twice(iterable $data, callable $filter): bool
+    public static function twice(iterable $data, callable $filter, bool $includeKey = false): bool
     {
-        return self::hasFoundTimes($data, $filter, 2);
+        return self::hasFoundTimes($data, $filter, 2, $includeKey);
     }
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
      * @param callable(mixed $datum): bool  $filter
      */
-    public static function times(iterable $data, callable $filter, int $count): bool
+    public static function times(iterable $data, callable $filter, int $count, bool $includeKey = false): bool
     {
-        return self::hasFoundTimes($data, $filter, $count);
+        return self::hasFoundTimes($data, $filter, $count, $includeKey);
     }
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    private static function hasFoundTimes(iterable $data, callable $filter, int $maxCount): bool
+    private static function hasFoundTimes(iterable $data, callable $filter, int $maxCount, bool $includeKey = false): bool
     {
         // usage must be higher than 0
         Assert::greaterThan($maxCount, 0);
 
         $totalFound = 0;
-        foreach ($data as $datum) {
-            $isFound = $filter($datum);
+        foreach ($data as $key => $datum) {
+            $isFound = $filter($datum, $includeKey ? $key : null);
 
             // returns of callable must be bool
             Assert::boolean($isFound);

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -73,6 +73,7 @@ final class Finder
         // go to end of array
         end($data);
 
+        // grab current key
         $key = key($data);
 
         // key = null means no longer current data
@@ -87,7 +88,7 @@ final class Finder
                 // go to previous row
                 prev($data);
 
-                // re-set key variable with new key value
+                // re-set key variable with new key value of previous row
                 $key = key($data);
 
                 continue;

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -19,12 +19,12 @@ final class Finder
 {
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function first(iterable $data, callable $filter): mixed
+    public static function first(iterable $data, callable $filter, bool $includeKey = false): mixed
     {
-        foreach ($data as $datum) {
-            $isFound = $filter($datum);
+        foreach ($data as $key => $datum) {
+            $isFound = $filter($datum, $includeKey ? $key : null);
 
             // returns of callable must be bool
             Assert::boolean($isFound);
@@ -54,9 +54,9 @@ final class Finder
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function last(iterable $data, callable $filter): mixed
+    public static function last(iterable $data, callable $filter, bool $includeKey = false): mixed
     {
         // convert to array when data is Traversable instance
         if ($data instanceof Traversable) {
@@ -73,10 +73,12 @@ final class Finder
         // go to end of array
         end($data);
 
+        $key = key($data);
+
         // key = null means no longer current data
-        while (key($data) !== null) {
+        while ($key !== null) {
             $current = current($data);
-            $isFound = $filter($current);
+            $isFound = $filter($current, $includeKey ? $key : null);
 
             // returns of callable must be bool
             Assert::boolean($isFound);
@@ -84,6 +86,9 @@ final class Finder
             if (! $isFound) {
                 // go to previous row
                 prev($data);
+
+                // re-set key variable with new key value
+                $key = key($data);
 
                 continue;
             }

--- a/src/Only.php
+++ b/src/Only.php
@@ -11,43 +11,43 @@ final class Only
 {
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function once(iterable $data, callable $filter): bool
+    public static function once(iterable $data, callable $filter, bool $includeKey = false): bool
     {
-        return self::onlyFoundTimes($data, $filter, 1);
+        return self::onlyFoundTimes($data, $filter, 1, $includeKey);
     }
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function twice(iterable $data, callable $filter): bool
+    public static function twice(iterable $data, callable $filter, bool $includeKey = false): bool
     {
-        return self::onlyFoundTimes($data, $filter, 2);
+        return self::onlyFoundTimes($data, $filter, 2, $includeKey);
     }
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function times(iterable $data, callable $filter, int $count): bool
+    public static function times(iterable $data, callable $filter, int $count, bool $includeKey = false): bool
     {
-        return self::onlyFoundTimes($data, $filter, $count);
+        return self::onlyFoundTimes($data, $filter, $count, $includeKey);
     }
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum): bool $filter
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    private static function onlyFoundTimes(iterable $data, callable $filter, int $maxCount): bool
+    private static function onlyFoundTimes(iterable $data, callable $filter, int $maxCount, bool $includeKey = false): bool
     {
         // usage must be higher than 0
         Assert::greaterThan($maxCount, 0);
 
         $totalFound = 0;
-        foreach ($data as $datum) {
-            $isFound = $filter($datum);
+        foreach ($data as $key => $datum) {
+            $isFound = $filter($datum, $includeKey ? $key : null);
 
             // returns of callable must be bool
             Assert::boolean($isFound);

--- a/src/Only.php
+++ b/src/Only.php
@@ -40,8 +40,12 @@ final class Only
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
      * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    private static function onlyFoundTimes(iterable $data, callable $filter, int $maxCount, bool $includeKey = false): bool
-    {
+    private static function onlyFoundTimes(
+        iterable $data,
+        callable $filter,
+        int $maxCount,
+        bool $includeKey = false
+    ): bool {
         // usage must be higher than 0
         Assert::greaterThan($maxCount, 0);
 

--- a/tests/AtLeastTest.php
+++ b/tests/AtLeastTest.php
@@ -7,6 +7,9 @@ namespace ArrayLookup\Tests;
 use ArrayLookup\AtLeast;
 use PHPUnit\Framework\TestCase;
 
+use function is_int;
+use function str_contains;
+
 final class AtLeastTest extends TestCase
 {
     /**
@@ -34,6 +37,19 @@ final class AtLeastTest extends TestCase
                 false,
             ],
         ];
+    }
+
+    public function testOnceIncludekey(): void
+    {
+        $filter = static fn(mixed $datum, ?int $key): bool => str_contains((string) $datum, 'test') && is_int($key);
+        $data   = [
+            0 => 'abc',
+            1 => 'def',
+            2 => 'some test',
+        ];
+
+        $this->assertTrue(AtLeast::once($data, $filter, true));
+        $this->assertFalse(AtLeast::once($data, $filter, false));
     }
 
     /**
@@ -66,6 +82,19 @@ final class AtLeastTest extends TestCase
 
     // phpcs:enable
 
+    public function testTwiceIncludekey(): void
+    {
+        $filter = static fn(mixed $datum, ?int $key): bool => str_contains((string) $datum, 'test') && is_int($key);
+        $data   = [
+            0 => 'abc',
+            1 => 'def test',
+            2 => 'some test',
+        ];
+
+        $this->assertTrue(AtLeast::twice($data, $filter, true));
+        $this->assertFalse(AtLeast::twice($data, $filter, false));
+    }
+
     /**
      * @dataProvider timesDataProvider
      */
@@ -91,5 +120,18 @@ final class AtLeastTest extends TestCase
                 false,
             ],
         ];
+    }
+
+    public function testTimesIncludekey(): void
+    {
+        $filter = static fn(mixed $datum, ?int $key): bool => str_contains((string) $datum, 'test') && is_int($key);
+        $data   = [
+            0 => 'abc test',
+            1 => 'def test',
+            2 => 'some test',
+        ];
+
+        $this->assertTrue(AtLeast::times($data, $filter, 3, true));
+        $this->assertFalse(AtLeast::times($data, $filter, 3, false));
     }
 }

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -10,6 +10,9 @@ use ArrayObject;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
+use function is_int;
+use function str_contains;
+
 final class FinderTest extends TestCase
 {
     /**
@@ -37,6 +40,19 @@ final class FinderTest extends TestCase
                 null,
             ],
         ];
+    }
+
+    public function testOnceIncludekey(): void
+    {
+        $filter = static fn(mixed $datum, ?int $key): bool => str_contains((string) $datum, 'test') && is_int($key);
+        $data   = [
+            0 => 'abc test',
+            1 => 'def',
+            2 => 'some test',
+        ];
+
+        $this->assertSame('abc test', Finder::first($data, $filter, true));
+        $this->assertNull(Finder::first($data, $filter, false));
     }
 
     /**
@@ -101,5 +117,18 @@ final class FinderTest extends TestCase
                 null,
             ],
         ];
+    }
+
+    public function testLastIncludekey(): void
+    {
+        $filter = static fn(mixed $datum, ?int $key): bool => str_contains((string) $datum, 'test') && is_int($key);
+        $data   = [
+            0 => 'abc test',
+            1 => 'def',
+            2 => 'some test',
+        ];
+
+        $this->assertSame('some test', Finder::last($data, $filter, true));
+        $this->assertNull(Finder::last($data, $filter, false));
     }
 }

--- a/tests/OnlyTest.php
+++ b/tests/OnlyTest.php
@@ -8,6 +8,9 @@ use ArrayLookup\Only;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function is_int;
+use function str_contains;
+
 final class OnlyTest extends TestCase
 {
     /**
@@ -36,6 +39,19 @@ final class OnlyTest extends TestCase
                 false,
             ],
         ];
+    }
+
+    public function testOnceIncludekey(): void
+    {
+        $filter = static fn(mixed $datum, ?int $key): bool => str_contains((string) $datum, 'test') && is_int($key);
+        $data   = [
+            0 => 'abc',
+            1 => 'def',
+            2 => 'some test',
+        ];
+
+        $this->assertTrue(Only::once($data, $filter, true));
+        $this->assertFalse(Only::once($data, $filter, false));
     }
 
     // phpcs:enable
@@ -68,6 +84,19 @@ final class OnlyTest extends TestCase
         ];
     }
 
+    public function testTwiceIncludekey(): void
+    {
+        $filter = static fn(mixed $datum, ?int $key): bool => str_contains((string) $datum, 'test') && is_int($key);
+        $data   = [
+            0 => 'abc',
+            1 => 'def test',
+            2 => 'some test',
+        ];
+
+        $this->assertTrue(Only::twice($data, $filter, true));
+        $this->assertFalse(Only::twice($data, $filter, false));
+    }
+
     // phpcs:enable
 
     /**
@@ -95,5 +124,18 @@ final class OnlyTest extends TestCase
                 false,
             ],
         ];
+    }
+
+    public function testTimesIncludekey(): void
+    {
+        $filter = static fn(mixed $datum, ?int $key): bool => str_contains((string) $datum, 'test') && is_int($key);
+        $data   = [
+            0 => 'abc test',
+            1 => 'def test',
+            2 => 'some test',
+        ];
+
+        $this->assertTrue(Only::times($data, $filter, 3, true));
+        $this->assertFalse(Only::times($data, $filter, 3, false));
     }
 }


### PR DESCRIPTION
To allow do:

```php
/** @param string $datum **/
$filter = static fn(mixed $datum, int $key): bool => str_contains($datum, 'test') && $key > 1;

$data   = [
        0 => 'abc',
        1 => 'def',
        2 => 'some test', 
];

 var_dump(AtLeast::once($data, $filter, true)); // true