### PR TITLE
Add returnKey flag on Finder to allow return key instead of row

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ var_dump(\ArrayLookup\Finder::last(
 var_dump(\ArrayLookup\Finder::last(
     $data,
     static fn ($datum): bool => $datum < 5,
-    3
+    true
 )); // null
 
 // WITH key array included

--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ var_dump(\ArrayLookup\Finder::first($data, $filter)) // 1
 $filter = static fn($datum): bool => $datum == 1000;
 var_dump(\ArrayLookup\Finder::first($data, $filter)) // null
 
+// RETURN the Array key
+
+$filter = static fn($datum): bool => $datum === 1;
+
+var_dump(\ArrayLookup\Finder::first($data, $filter, true)) // 0
+
+$filter = static fn($datum): bool => $datum == 1000;
+var_dump(\ArrayLookup\Finder::first($data, $filter, true)) // null
+
 // WITH key array included
 
 $filter = static fn($datum, $key): bool => $datum === 1 && $key >= 0;
@@ -257,6 +266,20 @@ var_dump(\ArrayLookup\Finder::last(
 var_dump(\ArrayLookup\Finder::last(
     $data,
     static fn ($datum): bool => $datum < 5
+)); // null
+
+// RETURN the Array key
+
+var_dump(\ArrayLookup\Finder::last(
+    $data,
+    static fn ($datum): bool => $datum > 5,
+    true
+)); // 3
+
+var_dump(\ArrayLookup\Finder::last(
+    $data,
+    static fn ($datum): bool => $datum < 5,
+    3
 )); // null
 
 // WITH key array included

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $filter = static fn($datum): bool => $datum === 4;
 
 var_dump(\ArrayLookup\AtLeast::once($data, $filter)) // false
 
-// WITH key array included
+// WITH key array included, pass $key variable as 2nd arg on  filter to be used in filter
 
 $data = [1, 2, 3];
 $filter = static fn($datum, $key): bool => $datum === 1 && $key >= 0;
@@ -77,7 +77,7 @@ $filter = static fn($datum): bool => $datum === 1;
 
 var_dump(\ArrayLookup\AtLeast::twice($data, $filter)) // false
 
-// WITH key array included
+// WITH key array included, pass $key variable as 2nd arg on  filter to be used in filter
 
 $data = [1, "1", 3];
 $filter = static fn($datum, $key): bool => $datum == 1 && $key >= 0;
@@ -107,7 +107,7 @@ $times = 3;
 
 var_dump(\ArrayLookup\AtLeast::times($data, $filter, $times)) // false
 
-// WITH key array included
+// WITH key array included, pass $key variable as 2nd arg on  filter to be used in filter
 
 $data = [false, null, 0];
 $filter = static fn($datum, $key): bool => ! $datum && $key >= 0;
@@ -141,7 +141,7 @@ $filter = static fn($datum): bool => $datum == 1;
 
 var_dump(\ArrayLookup\Only::once($data, $filter)) // false
 
-// WITH key array included
+// WITH key array included, pass $key variable as 2nd arg on  filter to be used in filter
 
 $data = [1, 2, 3];
 $filter = static fn($datum, $key): bool => $datum === 1 && $key >= 0;
@@ -170,7 +170,7 @@ $filter = static fn($datum): bool => (bool) $datum;
 
 var_dump(\ArrayLookup\Only::twice($data, $filter)) // false
 
-// WITH key array included
+// WITH key array included, pass $key variable as 2nd arg on  filter to be used in filter
 
 $data = [1, "1", 3];
 $filter = static fn($datum, $key): bool => $datum == 1 && $key >= 0;
@@ -201,7 +201,7 @@ $times = 2;
 
 var_dump(\ArrayLookup\Only::times($data, $filter, $times)) // false
 
-// WITH key array included
+// WITH key array included, pass $key variable as 2nd arg on  filter to be used in filter
 
 $data = [false, null, 1];
 $filter = static fn($datum, $key): bool => ! $datum && $key >= 0;
@@ -233,7 +233,7 @@ var_dump(\ArrayLookup\Finder::first($data, $filter)) // 1
 $filter = static fn($datum): bool => $datum == 1000;
 var_dump(\ArrayLookup\Finder::first($data, $filter)) // null
 
-// RETURN the Array key
+// RETURN the Array key, pass true to 3rd arg
 
 $filter = static fn($datum): bool => $datum === 1;
 
@@ -242,7 +242,7 @@ var_dump(\ArrayLookup\Finder::first($data, $filter, true)) // 0
 $filter = static fn($datum): bool => $datum == 1000;
 var_dump(\ArrayLookup\Finder::first($data, $filter, true)) // null
 
-// WITH key array included
+// WITH key array included, pass $key variable as 2nd arg on  filter to be used in filter
 
 $filter = static fn($datum, $key): bool => $datum === 1 && $key >= 0;
 
@@ -268,7 +268,7 @@ var_dump(\ArrayLookup\Finder::last(
     static fn ($datum): bool => $datum < 5
 )); // null
 
-// RETURN the Array key
+// RETURN the Array key, pass true to 3rd arg
 
 var_dump(\ArrayLookup\Finder::last(
     $data,
@@ -282,7 +282,7 @@ var_dump(\ArrayLookup\Finder::last(
     true
 )); // null
 
-// WITH key array included
+// WITH key array included, pass $key variable as 2nd arg on  filter to be used in filter
 
 var_dump(\ArrayLookup\Finder::last(
     $data,

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -21,7 +21,7 @@ final class Finder
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
      * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function first(iterable $data, callable $filter): mixed
+    public static function first(iterable $data, callable $filter, bool $returnKey = false): mixed
     {
         foreach ($data as $key => $datum) {
             $isFound = $filter($datum, $key);
@@ -33,7 +33,7 @@ final class Finder
                 continue;
             }
 
-            return $datum;
+            return $returnKey ? $key : $datum;
         }
 
         return null;
@@ -56,7 +56,7 @@ final class Finder
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
      * @param callable(mixed $datum, int|string|null $key=): bool $filter
      */
-    public static function last(iterable $data, callable $filter): mixed
+    public static function last(iterable $data, callable $filter, bool $returnKey = false): mixed
     {
         // convert to array when data is Traversable instance
         if ($data instanceof Traversable) {
@@ -94,7 +94,7 @@ final class Finder
                 continue;
             }
 
-            return $current;
+            return $returnKey ? $key : $current;
         }
 
         return null;

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -52,6 +52,43 @@ final class FinderTest extends TestCase
     }
 
     /**
+     * @dataProvider firstReturnKeyDataProvider
+     */
+    public function testFirstReturnKey(iterable $data, callable $filter, mixed $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            Finder::first($data, $filter, true)
+        );
+    }
+
+    public function firstReturnKeyDataProvider(): array
+    {
+        return [
+            [
+                [1, 2, 3],
+                static fn($datum): bool => $datum === 2,
+                1,
+            ],
+            [
+                [1, "1", 3],
+                static fn($datum): bool => $datum === 1000,
+                null,
+            ],
+            [
+                ['abc test', 'def', 'some test'],
+                static fn(string $datum, int $key): bool => str_contains($datum, 'test') && $key >= 0,
+                0,
+            ],
+            [
+                ['abc test', 'def', 'some test'],
+                static fn(string $datum, int $key): bool => str_contains($datum, 'test') && $key === 1,
+                null,
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider lastDataProvider
      */
     public function testLast(iterable $data, callable $filter, mixed $expected): void
@@ -116,6 +153,80 @@ final class FinderTest extends TestCase
                 ['abc test', 'def', 'some test'],
                 static fn(string $datum, int $key): bool => str_contains($datum, 'test') && $key >= 0,
                 'some test',
+            ],
+            [
+                ['abc test', 'def', 'some test'],
+                static fn(string $datum, int $key): bool => str_contains($datum, 'test') && $key === 1,
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider lastReturnKeyDataProvider
+     */
+    public function testLastReturnKey(iterable $data, callable $filter, mixed $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            Finder::last($data, $filter, true)
+        );
+    }
+
+    public function lastReturnKeyDataProvider(): array
+    {
+        $generator = static function (): Generator {
+            yield 6;
+            yield 7;
+            yield 8;
+            yield 9;
+        };
+
+        return [
+            [
+                [6, 7, 8, 9],
+                static fn($datum): bool => $datum > 5,
+                3,
+            ],
+            [
+                [6, 7, 8, 9],
+                static fn($datum): bool => $datum < 5,
+                null,
+            ],
+            [
+                new ArrayIterator([6, 7, 8, 9]),
+                static fn($datum): bool => $datum > 5,
+                3,
+            ],
+            [
+                new ArrayIterator([6, 7, 8, 9]),
+                static fn($datum): bool => $datum < 5,
+                null,
+            ],
+            [
+                new ArrayObject([6, 7, 8, 9]),
+                static fn($datum): bool => $datum > 5,
+                3,
+            ],
+            [
+                new ArrayObject([6, 7, 8, 9]),
+                static fn($datum): bool => $datum < 5,
+                null,
+            ],
+            [
+                $generator(),
+                static fn($datum): bool => $datum > 5,
+                3,
+            ],
+            [
+                $generator(),
+                static fn($datum): bool => $datum < 5,
+                null,
+            ],
+            [
+                ['abc test', 'def', 'some test'],
+                static fn(string $datum, int $key): bool => str_contains($datum, 'test') && $key >= 0,
+                2,
             ],
             [
                 ['abc test', 'def', 'some test'],


### PR DESCRIPTION
To allow search in both `first` or `last` to get the key instead of the row:

```php
$data = [1, 2, 3];
$filter = static fn($datum): bool => $datum === 1;

var_dump(\ArrayLookup\Finder::first($data, $filter, true)) // 0
```