### PR TITLE
Add Collector class

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features
 - [x] Verify at least times: `once()`, `twice()`, `times()`
 - [x] Verify exact times: `once()`, `twice()`, `times()`
 - [x] Search data: `first()`, `last()`, `rows()`
+- [x] Collect data with filter and transform
 
 Installation
 ------------
@@ -366,4 +367,37 @@ $limit = 1;
 var_dump(
     Finder::rows($data, $filter, limit: $limit)
 ); // [1]
+```
+
+**4. Collector**
+---------------
+
+It collect filtered data, with new transformed each data found:
+
+**Before**
+
+```php
+$newArray = [];
+
+foreach ($data as $datum) {
+    if (is_string($datum)) {
+        $newArray[] = trim($datum);
+    }
+}
+```
+
+**After**
+
+```php
+use ArrayLookup::Collector;
+
+$when = fn ($datum): bool => is_string($datum);
+$limit = 2;
+$transform = fn ($datum): string => trim($datum);
+
+$newArray = Collector::setUp($data)
+       ->when($when)
+       ->withLimit(2) // optional to only collect some data provided by limit config
+       ->withTransform($transform)
+       ->getResults();
 ```

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ foreach ($data as $datum) {
 **After**
 
 ```php
-use ArrayLookup::Collector;
+use ArrayLookup\Collector;
 
 $when = fn ($datum): bool => is_string($datum);
 $limit = 2;

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -9,19 +9,13 @@ use Webmozart\Assert\Assert;
 
 final class Collector
 {
-    /**
-     * @var array<int|string, mixed>|Traversable<int|string, mixed>
-     */
+    /** @var array<int|string, mixed>|Traversable<int|string, mixed> */
     private static iterable $data = [];
 
-    /**
-     * @var callable(mixed $datum, int|string|null $key=): bool|null
-     */
+    /** @var callable(mixed $datum, int|string|null $key=): bool|null */
     private $when;
 
-    /**
-     * @var callable(mixed $datum, int|string|null $key=): mixed
-     */
+    /** @var callable(mixed $datum, int|string|null $key=): mixed */
     private $transform;
 
     private ?int $limit = null;
@@ -31,7 +25,7 @@ final class Collector
      */
     public static function setUp(iterable $data): self
     {
-        $self = new self();
+        $self        = new self();
         $self->$data = $data;
 
         return $self;
@@ -72,7 +66,7 @@ final class Collector
         Assert::isCallable($this->when);
         Assert::isCallable($this->transform);
 
-        $count = 0;
+        $count         = 0;
         $collectedData = [];
 
         foreach ($this->data as $key => $datum) {

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArrayLookup;
+
+use Traversable;
+use Webmozart\Assert\Assert;
+
+final class Collector
+{
+    /**
+     * @var array<int|string, mixed>|Traversable<int|string, mixed>
+     */
+    private static iterable $data = [];
+
+    /**
+     * @var callable(mixed $datum, int|string|null $key=): bool|null
+     */
+    private $when;
+
+    /**
+     * @var callable(mixed $datum, int|string|null $key=): mixed
+     */
+    private $transform;
+
+    private ?int $limit = null;
+
+    /**
+     * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
+     */
+    public static function setUp(iterable $data): self
+    {
+        $self = new self();
+        $self->$data = $data;
+
+        return $self;
+    }
+
+    /**
+     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     */
+    public function when(callable $filter): self
+    {
+        $this->when = $filter;
+        return $this;
+    }
+
+    public function withLimit(int $limit): self
+    {
+        Assert::positiveInteger($limit);
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    /**
+     * @param callable(mixed $datum, int|string|null $key=): mixed $transform
+     */
+    public function withTransform(callable $transform): self
+    {
+        $this->transform = $transform;
+        return $this;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getResults(): array
+    {
+        // ensure when property is set early via ->when() and ->withTransform() method
+        Assert::isCallable($this->when);
+        Assert::isCallable($this->transform);
+
+        $count = 0;
+        $collectedData = [];
+
+        foreach ($this->data as $key => $datum) {
+            $isFound = ($this->when)($datum, $key);
+
+            Assert::boolean($isFound);
+
+            if (! $isFound) {
+                continue;
+            }
+
+            $collectedData[] = ($this->transform)($datum, $key);
+
+            ++$count;
+
+            if ($this->limit === $count) {
+                break;
+            }
+        }
+
+        return $collectedData;
+    }
+}

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
 final class Collector
 {
     /** @var array<int|string, mixed>|Traversable<int|string, mixed> */
-    private static iterable $data = [];
+    private iterable $data = [];
 
     /** @var callable(mixed $datum, int|string|null $key=): bool|null */
     private $when;
@@ -25,8 +25,8 @@ final class Collector
      */
     public static function setUp(iterable $data): self
     {
-        $self        = new self();
-        $self->$data = $data;
+        $self       = new self();
+        $self->data = $data;
 
         return $self;
     }

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArrayLookup\Tests;
+
+use ArrayLookup\Collector;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function is_string;
+use function trim;
+
+final class CollectorTest extends TestCase
+{
+    public function testWithoutLimit(): void
+    {
+        $data = [
+            ' a ',
+            ' b ',
+            ' c ',
+            new stdClass(),
+        ];
+
+        $results = Collector::setUp($data)
+            ->when(fn (mixed $datum): bool => is_string($datum))
+            ->withTransform(fn (string $datum): string => trim($datum))
+            ->getResults();
+
+        $this->assertSame(['a', 'b', 'c'], $results);
+    }
+
+    public function testWithLimit(): void
+    {
+        $data = [
+            ' a ',
+            ' b ',
+            ' c ',
+            new stdClass(),
+        ];
+
+        $results = Collector::setUp($data)
+            ->when(fn (mixed $datum): bool => is_string($datum))
+            ->withTransform(fn (string $datum): string => trim($datum))
+            ->withLimit(1)
+            ->getResults();
+
+        $this->assertSame(['a'], $results);
+    }
+}


### PR DESCRIPTION
To allow collect with filtered and transformed data, for example, for data:

**Before**

```php
$newArray = [];

foreach ($data as $datum) {
    if (is_string($datum)) {
        $newArray[] = trim($datum);
    }
}
```

**After**

```php
use ArrayLookup\Collector;

$when = fn (mixed $datum): bool => is_string($datum);
$limit = 2;
$transform = fn (string $datum): string => trim($datum);

$newArray = Collector::setUp($data)
       ->when($when)
       ->withLimit(2) // optional to only collect some data provided by limit config
       ->withTransform($transform)
       ->getResults();
```

Closes https://github.com/samsonasik/ArrayLookup/issues/19