### PR TITLE
Allow optional when on Collector class

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ $limit = 2;
 $transform = fn ($datum): string => trim($datum);
 
 $newArray = Collector::setUp($data)
-       ->when($when)
+       ->when($when) // optional, can just transform without filtering
        ->withLimit(2) // optional to only collect some data provided by limit config
        ->withTransform($transform)
        ->getResults();

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -12,10 +12,10 @@ final class Collector
     /** @var array<int|string, mixed>|Traversable<int|string, mixed> */
     private iterable $data = [];
 
-    /** @var callable(mixed $datum, int|string|null $key=): bool|null */
+    /** @var null|callable(mixed $datum, int|string|null $key=): bool */
     private $when;
 
-    /** @var callable(mixed $datum, int|string|null $key=): mixed */
+    /** @var null|callable(mixed $datum, int|string|null $key=): mixed */
     private $transform;
 
     private ?int $limit = null;
@@ -62,20 +62,22 @@ final class Collector
      */
     public function getResults(): array
     {
-        // ensure when property is set early via ->when() and ->withTransform() method
-        Assert::isCallable($this->when);
+        // ensure transform property is set early ->withTransform() method
         Assert::isCallable($this->transform);
 
         $count         = 0;
         $collectedData = [];
+        $isCallableWhen = is_callable($this-when);
 
         foreach ($this->data as $key => $datum) {
-            $isFound = ($this->when)($datum, $key);
+            if ($isCallableWhen) {
+                $isFound = ($this->when)($datum, $key);
 
-            Assert::boolean($isFound);
+                Assert::boolean($isFound);
 
-            if (! $isFound) {
-                continue;
+                if (! $isFound) {
+                    continue;
+                }
             }
 
             $collectedData[] = ($this->transform)($datum, $key);

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -7,6 +7,8 @@ namespace ArrayLookup;
 use Traversable;
 use Webmozart\Assert\Assert;
 
+use function is_callable;
+
 final class Collector
 {
     /** @var array<int|string, mixed>|Traversable<int|string, mixed> */
@@ -65,9 +67,9 @@ final class Collector
         // ensure transform property is set early ->withTransform() method
         Assert::isCallable($this->transform);
 
-        $count         = 0;
-        $collectedData = [];
-        $isCallableWhen = is_callable($this-when);
+        $count          = 0;
+        $collectedData  = [];
+        $isCallableWhen = is_callable($this->when);
 
         foreach ($this->data as $key => $datum) {
             if ($isCallableWhen) {

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -70,11 +70,13 @@ final class Collector
         $count          = 0;
         $collectedData  = [];
         $isCallableWhen = is_callable($this->when);
-        $when           = $this->when;
 
         foreach ($this->data as $key => $datum) {
             if ($isCallableWhen) {
-                /** @var callable(mixed $datum, int|string|null $key=): bool $when */
+                /**
+                 * @var callable(mixed $datum, int|string|null $key=): bool $when
+                 */
+                $when    = $this->when;
                 $isFound = ($when)($datum, $key);
 
                 Assert::boolean($isFound);

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -70,10 +70,12 @@ final class Collector
         $count          = 0;
         $collectedData  = [];
         $isCallableWhen = is_callable($this->when);
+        $when           = $this->when;
 
         foreach ($this->data as $key => $datum) {
             if ($isCallableWhen) {
-                $isFound = ($this->when)($datum, $key);
+                /** @var callable(mixed $datum, int|string|null $key=): bool $when */
+                $isFound = ($when)($datum, $key);
 
                 Assert::boolean($isFound);
 

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -13,6 +13,21 @@ use function trim;
 
 final class CollectorTest extends TestCase
 {
+    public function testWithoutWhen(): void
+    {
+        $data = [
+            ' a ',
+            ' b ',
+            ' c ',
+        ];
+
+        $results = Collector::setUp($data)
+            ->withTransform(fn (string $datum): string => trim($datum))
+            ->getResults();
+
+        $this->assertSame(['a', 'b', 'c'], $results);
+    }
+
     public function testWithoutLimit(): void
     {
         $data = [


### PR DESCRIPTION
Allow when callable to optional, so can be like this:

```php
        $data = [
            ' a ',
            ' b ',
            ' c ',
        ];

        $results = Collector::setUp($data)
            ->withTransform(fn (string $datum): string => trim($datum))
            ->getResults(); // ['a', 'b', 'c']
```