### PR TITLE
Fix Psalm Crash by Removing Equals Sign in @param Annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build/logs/*
 /.phpunit.result.cache
 /.phpunit.cache
+/.idea/

--- a/src/AtLeast.php
+++ b/src/AtLeast.php
@@ -11,7 +11,7 @@ final class AtLeast
 {
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed>  $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public static function once(iterable $data, callable $filter): bool
     {
@@ -20,7 +20,7 @@ final class AtLeast
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public static function twice(iterable $data, callable $filter): bool
     {
@@ -29,7 +29,7 @@ final class AtLeast
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool  $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public static function times(iterable $data, callable $filter, int $count): bool
     {
@@ -38,7 +38,7 @@ final class AtLeast
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     private static function atLeastFoundTimes(
         iterable $data,

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -14,10 +14,10 @@ final class Collector
     /** @var array<int|string, mixed>|Traversable<int|string, mixed> */
     private iterable $data = [];
 
-    /** @var null|callable(mixed $datum, int|string|null $key=): bool */
+    /** @var null|callable(mixed $datum, int|string|null $key): bool */
     private $when;
 
-    /** @var null|callable(mixed $datum, int|string|null $key=): mixed */
+    /** @var null|callable(mixed $datum, int|string|null $key): mixed */
     private $transform;
 
     private ?int $limit = null;
@@ -34,7 +34,7 @@ final class Collector
     }
 
     /**
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public function when(callable $filter): self
     {
@@ -51,7 +51,7 @@ final class Collector
     }
 
     /**
-     * @param callable(mixed $datum, int|string|null $key=): mixed $transform
+     * @param callable(mixed $datum, int|string|null $key): mixed $transform
      */
     public function withTransform(callable $transform): self
     {
@@ -74,7 +74,7 @@ final class Collector
         foreach ($this->data as $key => $datum) {
             if ($isCallableWhen) {
                 /**
-                 * @var callable(mixed $datum, int|string|null $key=): bool $when
+                 * @var callable(mixed $datum, int|string|null $key): bool $when
                  */
                 $when    = $this->when;
                 $isFound = ($when)($datum, $key);

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -20,7 +20,7 @@ final class Finder
 {
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public static function first(iterable $data, callable $filter, bool $returnKey = false): mixed
     {
@@ -55,7 +55,7 @@ final class Finder
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public static function last(
         iterable $data,
@@ -120,7 +120,7 @@ final class Finder
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      * @return mixed[]
      */
     public static function rows(

--- a/src/Only.php
+++ b/src/Only.php
@@ -11,7 +11,7 @@ final class Only
 {
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public static function once(iterable $data, callable $filter): bool
     {
@@ -20,7 +20,7 @@ final class Only
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public static function twice(iterable $data, callable $filter): bool
     {
@@ -29,7 +29,7 @@ final class Only
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     public static function times(iterable $data, callable $filter, int $count): bool
     {
@@ -38,7 +38,7 @@ final class Only
 
     /**
      * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
-     * @param callable(mixed $datum, int|string|null $key=): bool $filter
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
      */
     private static function onlyFoundTimes(
         iterable $data,


### PR DESCRIPTION
The pull request addresses an issue where the `@param` annotation for a callable parameter in the `src` classes causes Psalm to crash in downstream projects. The problem is due to the presence of an equals sign (`=`) in the annotation. The pull request removes the equals sign to prevent the crash.  

**Summary of changes:**
- Fixed the `@param` annotation for the `$filter` parameter in the classes to remove the equals sign (=).

**Details:**

- Updated the `@param` annotation for the `$filter` parameter in all affetcted methods to remove the equals sign (=) after int|string|null $key.

This change ensures compatibility with Psalm and prevents it from crashing in downstream projects.