### PR TITLE
Add Finder::partition() to splits data into 2 arrays: matching and non-matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features
 
 - [x] Verify at least times: `once()`, `twice()`, `times()`
 - [x] Verify exact times: `once()`, `twice()`, `times()`
-- [x] Search data: `first()`, `last()`, `rows()`
+- [x] Search data: `first()`, `last()`, `rows()`, `partition()`
 - [x] Collect data with filter and transform
 
 Installation
@@ -367,6 +367,38 @@ $limit = 1;
 var_dump(
     Finder::rows($data, $filter, limit: $limit)
 ); // [1]
+```
+
+#### 4. `Finder::partition()`
+
+It splits data into two arrays: matching and non-matching items based on a filter.
+
+```php
+use ArrayLookup\Finder;
+
+// Basic partition - split numbers into greater than 5 and not
+$data = [1, 6, 3, 8, 4, 9];
+$filter = static fn($datum): bool => $datum > 5;
+
+[$matching, $notMatching] = Finder::partition($data, $filter);
+
+var_dump($matching);    // [6, 8, 9]
+var_dump($notMatching); // [1, 3, 4]
+
+// Partition with preserved keys
+[$matching, $notMatching] = Finder::partition($data, $filter, preserveKey: true);
+
+var_dump($matching);    // [1 => 6, 3 => 8, 5 => 9]
+var_dump($notMatching); // [0 => 1, 2 => 3, 4 => 4]
+
+// Using the array key inside the filter
+$data = [10, 20, 30, 40];
+$keyFilter = static fn($datum, $key): bool => $key % 2 === 0;
+
+[$even, $odd] = Finder::partition($data, $keyFilter, preserveKey: true);
+
+var_dump($even); // [0 => 10, 2 => 30]
+var_dump($odd);  // [1 => 20, 3 => 40]
 ```
 
 **D. Collector**

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector;
@@ -25,6 +26,9 @@ return RectorConfig::configure()
         ],
         NarrowWideUnionReturnTypeRector::class              => [
             __DIR__ . '/tests/FilterTest.php',
+        ],
+        FunctionLikeToFirstClassCallableRector::class => [
+            __DIR__ . '/tests/FinderTest.php',
         ],
     ])
     ->withParallel()

--- a/rector.php
+++ b/rector.php
@@ -27,7 +27,7 @@ return RectorConfig::configure()
         NarrowWideUnionReturnTypeRector::class              => [
             __DIR__ . '/tests/FilterTest.php',
         ],
-        FunctionLikeToFirstClassCallableRector::class => [
+        FunctionLikeToFirstClassCallableRector::class       => [
             __DIR__ . '/tests/FinderTest.php',
         ],
     ])

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -165,4 +165,45 @@ final class Finder
 
         return $rows;
     }
+
+    /**
+     * Partitions data into two arrays: [matching, notMatching] based on filter.
+     *
+     * @param array<int|string, mixed>|Traversable<int|string, mixed> $data
+     * @param callable(mixed $datum, int|string|null $key): bool $filter
+     * @return array{0: array<int|string, mixed>, 1: array<int|string, mixed>}
+     */
+    public static function partition(
+        iterable $data,
+        callable $filter,
+        bool $preserveKey = false
+    ): array {
+        // filter must be a callable with bool return type
+        Filter::boolean($filter);
+
+        $matching    = [];
+        $notMatching = [];
+        $matchKey    = 0;
+        $notMatchKey = 0;
+
+        foreach ($data as $key => $datum) {
+            $isFound = $filter($datum, $key);
+
+            if ($isFound) {
+                if ($preserveKey || ! is_numeric($key)) {
+                    $matching[$key] = $datum;
+                } else {
+                    $matching[$matchKey] = $datum;
+                    ++$matchKey;
+                }
+            } elseif ($preserveKey || ! is_numeric($key)) {
+                $notMatching[$key] = $datum;
+            } else {
+                $notMatching[$notMatchKey] = $datum;
+                ++$notMatchKey;
+            }
+        }
+
+        return [$matching, $notMatching];
+    }
 }

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function current;
+use function is_string;
 use function str_contains;
 
 final class FinderTest extends TestCase


### PR DESCRIPTION
Add new `Finder::partition()` functionality:

It splits data into 2 arrays: matching and non-matching, instead of 2 loops to get match and non-match, it just use single iteration, and already get both matching and non-matching data.

The valid example for this:

```php
<?php
// Import CSV data and separate valid/invalid rows in one pass
$csvRows = $csvParser->parse('users.csv');
[$validUsers, $invalidUsers] = Finder::partition(
    $csvRows,
    fn($row) => $validator->validate($row)->isValid()
);

// Bulk insert valid users
$userRepository->bulkInsert($validUsers);

// Generate error report for invalid rows
$reportGenerator->createErrorReport($invalidUsers);
```