### PR TITLE
Make faster search on Finder::last() on SplFixedArray data

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -7,6 +7,7 @@ namespace ArrayLookup;
 use ArrayIterator;
 use ArrayLookup\Assert\Filter;
 use ArrayObject;
+use SplFixedArray;
 use Traversable;
 use Webmozart\Assert\Assert;
 
@@ -49,6 +50,10 @@ final class Finder
     {
         if ($traversable instanceof ArrayIterator || $traversable instanceof ArrayObject) {
             return $traversable->getArrayCopy();
+        }
+
+        if ($traversable instanceof SplFixedArray) {
+            return $traversable->toArray();
         }
 
         return iterator_to_array($traversable);

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -14,6 +14,7 @@ use Generator;
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use SplFixedArray;
 use stdClass;
 
 use function current;
@@ -246,6 +247,16 @@ final class FinderTest extends TestCase
         yield [
             ['abc test', 'def', 'some test'],
             static fn(string $datum, int $key): bool => str_contains($datum, 'test') && $key === 1,
+            null,
+        ];
+        yield [
+            SplFixedArray::fromArray([6, 7, 8, 9]),
+            static fn($datum): bool => $datum > 5,
+            3,
+        ];
+        yield [
+            SplFixedArray::fromArray([6, 7, 8, 9]),
+            static fn($datum): bool => $datum < 5,
             null,
         ];
     }


### PR DESCRIPTION
When data is `SplFixedArray` object, use `->toArray()` instead of `iterator_to_array()`.

```bash
Benchmark: SplFixedArray with 100000 elements
==================================================

Test 1: iterator_to_array()
  Average: 0.9139 ms
  Min: 0.8800 ms
  Max: 1.0941 ms

Test 2: SplFixedArray::toArray()
  Average: 0.3004 ms
  Min: 0.2842 ms
  Max: 0.3991 ms

==================================================
Comparison Results:
==================================================
iterator_to_array() is 204.27% slower
Speedup factor: 3.04x

Total time for 100 iterations:
  iterator_to_array(): 91.39 ms
  toArray(): 30.04 ms
  Difference: 61.35 ms
```