### PR TITLE
Fix limit to only allow positive value on validation on Finder::rows()

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -141,6 +141,7 @@ final class Finder
 
         // filter must be a callable with bool return type
         Filter::boolean($filter);
+        Assert::nullOrPositiveInteger($limit);
 
         foreach ($data as $key => $datum) {
             $isFound = $filter($datum, $key);

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -393,6 +393,9 @@ final class FinderTest extends TestCase
             ],
             Finder::rows($data, $filter, limit: 1)
         );
+
+        $this->expectExceptionMessage('Expected a positive integer. Got: 0');
+        Finder::rows($data, $filter, limit: 0);
     }
 
     /**


### PR DESCRIPTION
`$limit` 0 must not allowed.