### PR TITLE
Fix no space on min vs max on Interval::isExclusiveOf()

### DIFF
--- a/src/Interval.php
+++ b/src/Interval.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ArrayLookup;
 
 use ArrayLookup\Assert\Filter;
+use InvalidArgumentException;
 use Traversable;
 use Webmozart\Assert\Assert;
 
@@ -59,7 +60,9 @@ final class Interval
         Filter::boolean($filter);
 
         if ($max - $min <= 1) {
-            return false;
+            throw new InvalidArgumentException(
+                'The difference between min and max must be greater than 1 for an exclusive interval.'
+            );
         }
 
         $totalFound = 0;

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -140,36 +140,16 @@ final class IntervalTest extends TestCase
     /**
      * @param int[] $data
      */
-    #[DataProvider('noSpaceExclusiveDataProvider')]
-    public function testNoSpaceIntervalIsExclusiveOf(
-        array $data,
-        callable $filter,
-        int $min,
-        int $max
-    ): void {
+    public function testNoSpaceIntervalIsExclusiveOf(): void
+    {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The difference between min and max must be greater than 1 for an exclusive interval.');
 
+        $data = [1, 2, 3];
+        $filter = static fn($datum): bool => $datum > 1;
+        $min = 2;
+        $max = 3;
+
         Interval::isExclusiveOf($data, $filter, $min, $max);
-    }
-
-    /**
-     * @return Iterator<mixed>
-     */
-    public static function noSpaceExclusiveDataProvider(): Iterator
-    {
-        yield 'equal between bounds' => [
-            [1, 2, 3],
-            static fn($datum): bool => $datum > 1,
-            2,
-            2,
-        ];
-
-        yield 'no space between bounds' => [
-            [1, 2, 3],
-            static fn($datum): bool => $datum > 1,
-            2,
-            3,
-        ];
     }
 }

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ArrayLookup\Tests;
 
 use ArrayLookup\Interval;
+use InvalidArgumentException;
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -134,12 +135,39 @@ final class IntervalTest extends TestCase
             5,
             false,
         ];
+    }
+
+    /**
+     * @param int[] $data
+     */
+    #[DataProvider('noSpaceExclusiveDataProvider')]
+    public function testNoSpaceInterval(
+        array $data,
+        callable $filter,
+        int $min,
+        int $max
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        Interval::isExclusiveOf($data, $filter, $min, $max);
+    }
+
+    /**
+     * @return Iterator<mixed>
+     */
+    public static function noSpaceExclusiveDataProvider(): Iterator
+    {
+        yield 'equal between bounds' => [
+            [1, 2, 3],
+            static fn($datum): bool => $datum > 1,
+            2,
+            2,
+        ];
+
         yield 'no space between bounds' => [
             [1, 2, 3],
             static fn($datum): bool => $datum > 1,
             2,
             3,
-            false,
         ];
     }
 }

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -148,6 +148,8 @@ final class IntervalTest extends TestCase
         int $max
     ): void {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The difference between min and max must be greater than 1 for an exclusive interval.');
+
         Interval::isExclusiveOf($data, $filter, $min, $max);
     }
 

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -141,7 +141,7 @@ final class IntervalTest extends TestCase
      * @param int[] $data
      */
     #[DataProvider('noSpaceExclusiveDataProvider')]
-    public function testNoSpaceInterval(
+    public function testNoSpaceIntervalIsExclusiveOf(
         array $data,
         callable $filter,
         int $min,

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -145,10 +145,10 @@ final class IntervalTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The difference between min and max must be greater than 1 for an exclusive interval.');
 
-        $data = [1, 2, 3];
+        $data   = [1, 2, 3];
         $filter = static fn($datum): bool => $datum > 1;
-        $min = 2;
-        $max = 3;
+        $min    = 2;
+        $max    = 3;
 
         Interval::isExclusiveOf($data, $filter, $min, $max);
     }

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -137,13 +137,12 @@ final class IntervalTest extends TestCase
         ];
     }
 
-    /**
-     * @param int[] $data
-     */
     public function testNoSpaceIntervalIsExclusiveOf(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The difference between min and max must be greater than 1 for an exclusive interval.');
+        $this->expectExceptionMessage(
+            'The difference between min and max must be greater than 1 for an exclusive interval.'
+        );
 
         $data   = [1, 2, 3];
         $filter = static fn($datum): bool => $datum > 1;


### PR DESCRIPTION
Exclusive interval needs at least 1 number between min or max. This needs throw immediatelly instead of falsy return.